### PR TITLE
Add tag_prefix and tag_suffix placeholders

### DIFF
--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -101,18 +101,18 @@ module Fluent
           placeholders.store("${tag_parts[#{idx-size}]}", t) # support tag_parts[-1]
 
           tag_prefix = tag_prefix ? (tag_prefix + '.' + t) : t
-          placeholders.store("${tag_prefix[#{idx+1}]}", tag_prefix)
-          placeholders.store("${tag_prefix[#{idx-size+1}]}", tag_prefix) # support tag_prefix[-1]
+          placeholders.store("${tag_prefix[#{idx}]}", tag_prefix)
+          placeholders.store("${tag_prefix[#{idx-size}]}", tag_prefix) # support tag_prefix[-1]
 
           # tags is just for old version compatibility
           placeholders.store("${tags[#{idx}]}", t)
           placeholders.store("${tags[#{idx-size}]}", t) # support tags[-1]
         }
 
-        tag_parts.reverse.each_with_index { |t, idx|
+        tag_parts.reverse.each_with_index { |t, idx| # idx is reversed in this loop
           tag_suffix = tag_suffix ? (t + '.' + tag_suffix) : t
-          placeholders.store("${tag_suffix[#{idx+1}]}", tag_suffix)
-          placeholders.store("${tag_suffix[#{idx-size+1}]}", tag_suffix) # support tag_suffix[-1]
+          placeholders.store("${tag_suffix[#{size-idx-1}]}", tag_suffix)
+          placeholders.store("${tag_suffix[#{-idx-1}]}", tag_suffix) # support tag_suffix[-1]
         }
 
         record.each { |k, v|
@@ -141,9 +141,26 @@ module Fluent
       # @param [String] hostname    the hostname
       # @param [Time]   time        the time
       def prepare_placeholders(record, tag, tag_parts, hostname, time)
+        tag_prefix = []
+        tag_suffix = []
+        tmp_tag_prefix = nil
+        tmp_tag_suffix = nil
+
+        tag_parts.each { |t|
+          tmp_tag_prefix = tmp_tag_prefix ? (tmp_tag_prefix + '.' + t) : t
+          tag_prefix << tmp_tag_prefix
+        }
+
+        tag_parts.reverse.each { |t|
+          tmp_tag_suffix = tmp_tag_suffix ? (t + '.' + tmp_tag_suffix) : t
+          tag_suffix << tmp_tag_suffix
+        }
+
         struct = UndefOpenStruct.new(record)
         struct.tag  = tag
         struct.tags = struct.tag_parts = tag_parts # tags is for old version compatibility
+        struct.tag_prefix = tag_prefix
+        struct.tag_suffix = tag_suffix.reverse
         struct.time = time
         struct.hostname = hostname
         @placeholders = struct


### PR DESCRIPTION
For my particular use case, I found these new placeholders to be extremely useful.

I have logs coming from several servers, each prefixed with `hostname.*`, and I'm using record-reformer to add in extra per-host data before removing the hostname prefix.

**Placeholders added:**
- ${tag_prefix[N]} the first N tag_parts, negative values give all but the last N tag_parts
- ${tag_suffix[N]} the last N tag_parts, negative values give all but the first N tag_parts 

**Examples:**

```
Input tag: prefix.test.tag.suffix

${tag_prefix[1]} => prefix
${tag_prefix[-2]} => prefix.test
${tag_suffix[2]} => tag.suffix
${tag_suffix[-1]} => test.tag.suffix
```

I modified the tests a bit to cover these placeholders.
