### PR TITLE
Require 'ostruct' at top of file

### DIFF
--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -1,4 +1,5 @@
 require 'socket'
+require 'ostruct'
 
 module Fluent
   class RecordReformerOutput < Output


### PR DESCRIPTION
Resolves a (somewhat odd) error of "uninitialized constant Fluent::RecordReformerOutput::RubyPlaceholderExpander::OpenStruct" during initialization.
