### PR TITLE
remove_keys as a hash of symbol

### DIFF
--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -105,6 +105,7 @@ module Fluent
       @keep_keys.each {|k| new_record[k] = record[k]} if @keep_keys and @renew_record
       @map.each_pair {|k, v| new_record[k] = @placeholder_expander.expand(v) }
       @remove_keys.each {|k| new_record.delete(k) } if @remove_keys
+      @remove_keys.each {|k| new_record.delete(k.to_sym) } if @remove_keys
 
       [new_tag, new_record]
     end


### PR DESCRIPTION
fix for issue below:
https://github.com/shinsaka/fluent-plugin-elb-log/issues/8

This update remove keys as a hash of symbol.
Do you think about this fix?
Could you check it.

Thanks,
