### PR TITLE
Add `renew_time_key` option to emit with reformed time field

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ This results in same, but please note that following option parameters are reser
 
     `renew_record true` creates an output record newly without extending (merging) the input record fields. Default is `false`.
 
+- renew\_time\_key *string*
+
+    `renew_time_key foo` overwrite time of events with value of field `foo` if exist. The value of `foo` must be unix time.
+
 - keep_keys
 
     You may want to remain some record fields although you specify `renew_record true`. Then, specify record keys to be kept by a string separated by , (comma) like


### PR DESCRIPTION
Add a option parameter to re-emit events with reformed value for times.

Currently, once events are emitted with wrongly formatted times, then we cannot correct it in easy way.
This option is to provide way to do it.

For example, input logs have a `time` field/value with micro-second integer. Plugins emit events it as unix time.
This feature makes us to re-emit that event to correct time with configuration `time ${(time / 1000000).to_i}` and `renew_time_key time`.