### PR TITLE
Introduce special syntaxes to modify existing array fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ It is also possible to write a ruby code in placeholders if you set `enable_ruby
 
 but, please note that enabling ruby codes is not encouraged by security reasons and also in terms of the performance.
 
+## Modification of array fields
+
+There are special syntax to modify existing array fields:
+
+* `${field_name} + ["to be added 1", "to be added 2"]`
+  will construct a new array with added elements.
+* `${field_name} - ["to be removed 1", "to be removed 2"]`
+  will construct a new array without specified elements.
+
+Note that the left-hand will be converted to an array automatically, if the existing field is not an array type.
+
 ## Relatives
 
 Following plugins look similar:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Example:
         input_tag ${tag}
         last_tag ${tag_parts[-1]}
         message ${message}, yay!
+        members ${members} + ["Bob"]
       </record>
     </match>
 
@@ -35,7 +36,8 @@ Assume following input is coming (indented):
 foo.bar {
   "remove_me":"bar",
   "not_remove_me":"bar",
-  "message":"Hello world!"
+  "message":"Hello world!",
+  "members":["Alice"]
 }
 ```
 
@@ -48,6 +50,7 @@ reformed.foo {
   "input_tag":"foo.bar",
   "last_tag":"bar",
   "message":"Hello world!, yay!",
+  "members":["Alice","Bob"],
 }
 ```
 
@@ -66,6 +69,7 @@ Example:
       input_tag ${tag}
       last_tag ${tag_parts[-1]}
       message ${message}, yay!
+      members ${members} + ["Bob"]
     </match>
 
 This results in same, but please note that following option parameters are reserved, so can not be used as a record key.

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -328,7 +328,7 @@ EOC
             tag tag
             enable_ruby #{enable_ruby}
             <record>
-              array_field ["${hostname}", "${tag}"]
+              array_field ${array_field} + ["${hostname}", "${tag}"]
             </record>
           ]
           msgs = [

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -342,11 +342,12 @@ EOC
             { 'array_field' => 'not_array' },
             { 'array_field' => nil },
           ]
+          parsed_nil_field = enable_ruby == 'yes' ? [''] : []
           expected_results = [
             ['1', '2', @hostname, @tag],
             [@hostname, @tag],
             ['not_array', @hostname, @tag],
-            [@hostname, @tag],
+            parsed_nil_field + [@hostname, @tag],
           ]
           es = emit(config, use_v1, msgs)
           actual_results = []
@@ -370,11 +371,12 @@ EOC
             { 'array_field' => 'not_array' },
             { 'array_field' => nil },
           ]
+          parsed_nil_field = enable_ruby == 'yes' ? [''] : []
           expected_results = [
             [@tag],
             [],
             ['not_array'],
-            [],
+            parsed_nil_field + [],
           ]
           es = emit(config, use_v1, msgs)
           actual_results = []

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -340,6 +340,23 @@ EOC
           end
         end
 
+        test "removing array values from existing field with enable_ruby #{enable_ruby}" do
+          config = %[
+            tag tag
+            enable_ruby #{enable_ruby}
+            <record>
+              array_field ${array_field} - ["${hostname}"]
+            </record>
+          ]
+          msgs = [
+            { 'array_field' => [@hostname, @tag] },
+          ]
+          es = emit(config, use_v1, msgs)
+          es.each_with_index do |(tag, time, record), i|
+            assert_equal([@tag], record['array_field'])
+          end
+        end
+
         test "array and hash values with placeholders with enable_ruby #{enable_ruby}" do
           config = %[
             tag tag

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -27,7 +27,12 @@ class RecordReformerOutputTest < Test::Unit::TestCase
     d = create_driver(config, use_v1)
     d.run do
       msgs.each do |msg|
-        d.emit({'eventType0' => 'bar', 'message' => msg}, @time)
+        record = {
+          'eventType0' => 'bar',
+          'message'    => msg,
+        }
+        record = record.merge(msg) if msg.is_a?(Hash)
+        d.emit(record, @time)
       end
     end
 

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -338,11 +338,22 @@ EOC
           ]
           msgs = [
             { 'array_field' => ['1', '2'] },
+            { 'array_field' => [] },
+            { 'array_field' => 'not_array' },
+            { 'array_field' => nil },
+          ]
+          expected_results = [
+            ['1', '2', @hostname, @tag],
+            [@hostname, @tag],
+            ['not_array', @hostname, @tag],
+            [@hostname, @tag],
           ]
           es = emit(config, use_v1, msgs)
+          actual_results = []
           es.each_with_index do |(tag, time, record), i|
-            assert_equal(['1', '2', @hostname, @tag], record['array_field'])
+            actual_results << record['array_field']
           end
+          assert_equal(expected_results, actual_results)
         end
 
         test "removing array values from existing field with enable_ruby #{enable_ruby}" do
@@ -355,11 +366,22 @@ EOC
           ]
           msgs = [
             { 'array_field' => [@hostname, @tag] },
+            { 'array_field' => [] },
+            { 'array_field' => 'not_array' },
+            { 'array_field' => nil },
+          ]
+          expected_results = [
+            [@tag],
+            [],
+            ['not_array'],
+            [],
           ]
           es = emit(config, use_v1, msgs)
+          actual_results = []
           es.each_with_index do |(tag, time, record), i|
-            assert_equal([@tag], record['array_field'])
+            actual_results << record['array_field']
           end
+          assert_equal(expected_results, actual_results)
         end
 
         test "array and hash values with placeholders with enable_ruby #{enable_ruby}" do

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -323,6 +323,23 @@ EOC
           end
         end
 
+        test "adding array values to existing field with enable_ruby #{enable_ruby}" do
+          config = %[
+            tag tag
+            enable_ruby #{enable_ruby}
+            <record>
+              array_field ["${hostname}", "${tag}"]
+            </record>
+          ]
+          msgs = [
+            { 'array_field' => ['1', '2'] },
+          ]
+          es = emit(config, use_v1, msgs)
+          es.each_with_index do |(tag, time, record), i|
+            assert_equal(['1', '2', @hostname, @tag], record['array_field'])
+          end
+        end
+
         test "array and hash values with placeholders with enable_ruby #{enable_ruby}" do
           config = %[
             tag tag


### PR DESCRIPTION
This is just an idea to solve #22.

This PR introduces two special syntaxes to construct new array:

* `${field_name} + ["to be added 1", "to be added 2"]`
* `${field_name} - ["to be removed 1", "to be removed 2"]`

For more details, please see descriptions added to the README.

I think this will help me to define a post process filter to modify existing array fields like https://github.com/clear-code/sharetary/blob/master/sample/fluent-plugin-github-activities.conf#L343

On the other hand, this PR possibly breaks backward compatibility. If there is any existing configuration to output string like above syntaxes, it will construct unexpected results...