### PR TITLE
Autodetect field type

### DIFF
--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -16,7 +16,7 @@ module Fluent
     config_param :renew_record, :bool, :default => false
     config_param :renew_time_key, :string, :default => nil
     config_param :enable_ruby, :bool, :default => true # true for lower version compatibility
-    config_param :autodetect_field_type, :bool, :default => false # false for lower version compatibility
+    config_param :autodetect_value_type, :bool, :default => false # false for lower version compatibility
 
     BUILTIN_CONFIGURATIONS = %W(type tag output_tag remove_keys renew_record keep_keys enable_ruby renew_time_key)
 

--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -65,7 +65,7 @@ module Fluent
       end
 
       placeholder_expander_params = {
-        :log                   => log,
+        :log           => log,
         :auto_typecast => @auto_typecast,
       }
       @placeholder_expander =

--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -16,6 +16,7 @@ module Fluent
     config_param :renew_record, :bool, :default => false
     config_param :renew_time_key, :string, :default => nil
     config_param :enable_ruby, :bool, :default => true # true for lower version compatibility
+    config_param :autodetect_field_type, :bool, :default => false # false for lower version compatibility
 
     BUILTIN_CONFIGURATIONS = %W(type tag output_tag remove_keys renew_record keep_keys enable_ruby renew_time_key)
 

--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -16,7 +16,7 @@ module Fluent
     config_param :renew_record, :bool, :default => false
     config_param :renew_time_key, :string, :default => nil
     config_param :enable_ruby, :bool, :default => true # true for lower version compatibility
-    config_param :autodetect_value_type, :bool, :default => false # false for lower version compatibility
+    config_param :auto_typecast, :bool, :default => false # false for lower version compatibility
 
     BUILTIN_CONFIGURATIONS = %W(type tag output_tag remove_keys renew_record keep_keys enable_ruby renew_time_key)
 
@@ -66,7 +66,7 @@ module Fluent
 
       placeholder_expander_params = {
         :log                   => log,
-        :autodetect_value_type => @autodetect_value_type,
+        :auto_typecast => @auto_typecast,
       }
       @placeholder_expander =
         if @enable_ruby
@@ -179,7 +179,7 @@ module Fluent
 
       def initialize(params)
         @log = params[:log]
-        @autodetect_value_type = params[:autodetect_value_type]
+        @auto_typecast = params[:auto_typecast]
       end
 
       def prepare_placeholders(time, record, opts)
@@ -202,7 +202,7 @@ module Fluent
       end
 
       def expand(str, force_stringify=false)
-        if @autodetect_value_type and !force_stringify
+        if @auto_typecast and !force_stringify
           single_placeholder_matched = str.match(/\A(\${[^}]+}|__[A-Z_]+__)\z/)
           if single_placeholder_matched
             log_unknown_placeholder($1)
@@ -228,7 +228,7 @@ module Fluent
 
       def initialize(params)
         @log = params[:log]
-        @autodetect_value_type = params[:autodetect_value_type]
+        @auto_typecast = params[:auto_typecast]
       end
 
       # Get placeholders as a struct
@@ -247,7 +247,7 @@ module Fluent
       #
       # @param [String] str         the string to be replaced
       def expand(str, force_stringify=false)
-        if @autodetect_value_type and !force_stringify
+        if @auto_typecast and !force_stringify
           single_placeholder_matched = str.match(/\A\${([^}]+)}\z/)
           if single_placeholder_matched
             code = single_placeholder_matched[1]

--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -64,15 +64,19 @@ module Fluent
         raise Fluent::ConfigError, "out_record_reformer: `tag` must be specified"
       end
 
+      placeholder_expander_params = {
+        :log                   => log,
+        :autodetect_value_type => @autodetect_value_type,
+      }
       @placeholder_expander =
         if @enable_ruby
           # require utilities which would be used in ruby placeholders
           require 'pathname'
           require 'uri'
           require 'cgi'
-          RubyPlaceholderExpander.new(log)
+          RubyPlaceholderExpander.new(placeholder_expander_params)
         else
-          PlaceholderExpander.new(log)
+          PlaceholderExpander.new(placeholder_expander_params)
         end
 
       @hostname = Socket.gethostname
@@ -173,8 +177,9 @@ module Fluent
     class PlaceholderExpander
       attr_reader :placeholders, :log
 
-      def initialize(log)
-        @log = log
+      def initialize(params)
+        @log = params[:log]
+        @autodetect_value_type = params[:autodetect_value_type]
       end
 
       def prepare_placeholders(time, record, opts)
@@ -207,8 +212,9 @@ module Fluent
     class RubyPlaceholderExpander
       attr_reader :placeholders, :log
 
-      def initialize(log)
-        @log = log
+      def initialize(params)
+        @log = params[:log]
+        @autodetect_value_type = params[:autodetect_value_type]
       end
 
       # Get placeholders as a struct

--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -246,7 +246,14 @@ module Fluent
       # Replace placeholders in a string
       #
       # @param [String] str         the string to be replaced
-      def expand(str)
+      def expand(str, force_stringify=false)
+        if @autodetect_value_type and !force_stringify
+          single_placeholder_matched = str.match(/\A\${([^}]+)}\z/)
+          if single_placeholder_matched
+            code = single_placeholder_matched[1]
+            return eval code, @placeholders.instance_eval { binding }
+          end
+        end
         interpolated = str.gsub(/\$\{([^}]+)\}/, '#{\1}') # ${..} => #{..}
         eval "\"#{interpolated}\"", @placeholders.instance_eval { binding }
       rescue => e

--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -202,7 +202,7 @@ module Fluent
       end
 
       def expand(str, force_stringify=false)
-        if !force_stringify and @autodetect_value_type
+        if @autodetect_value_type and !force_stringify
           single_placeholder_matched = str.match(/\A(\${[^}]+}|__[A-Z_]+__)\z/)
           if single_placeholder_matched
             log_unknown_placeholder($1)

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -363,11 +363,11 @@ EOC
           end
         end
 
-        test "disabled autodetectction of field type with enable_ruby #{enable_ruby}" do
+        test "disabled autodetectction of value type with enable_ruby #{enable_ruby}" do
           config = %[
             tag tag
             enable_ruby #{enable_ruby}
-            autodetect_field_type false
+            autodetect_value_type false
             <record>
               single      ${source}
               multiple    ${source}${source}
@@ -417,11 +417,11 @@ EOC
           assert_equal(expected_results, actual_results)
         end
 
-        test "enabled autodetectction of field type with enable_ruby #{enable_ruby}" do
+        test "enabled autodetectction of value type with enable_ruby #{enable_ruby}" do
           config = %[
             tag tag
             enable_ruby #{enable_ruby}
-            autodetect_field_type true
+            autodetect_value_type true
             <record>
               single      ${source}
               multiple    ${source}${source}

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -27,7 +27,12 @@ class RecordReformerOutputTest < Test::Unit::TestCase
     d = create_driver(config, use_v1)
     d.run do
       msgs.each do |msg|
-        d.emit({'eventType0' => 'bar', 'message' => msg}, @time)
+        record = {
+          'eventType0' => 'bar',
+          'message'    => msg,
+        }
+        record = record.merge(msg) if msg.is_a?(Hash)
+        d.emit(record, @time)
       end
     end
 

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -367,7 +367,7 @@ EOC
           config = %[
             tag tag
             enable_ruby #{enable_ruby}
-            autodetect_value_type false
+            auto_typecast false
             <record>
               single      ${source}
               multiple    ${source}${source}
@@ -421,7 +421,7 @@ EOC
           config = %[
             tag tag
             enable_ruby #{enable_ruby}
-            autodetect_value_type true
+            auto_typecast true
             <record>
               single      ${source}
               multiple    ${source}${source}


### PR DESCRIPTION
This is inspired from the idea https://github.com/sonots/fluent-plugin-record-reformer/pull/24#issuecomment-113208964
By the new configuration "autodetect_value_type", the default behavior is compatible to old versions. How about this?