### PR TITLE
Add system parameters to BUILTIN_CONFIGURATIONS.

### DIFF
--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -18,7 +18,7 @@ module Fluent
     config_param :enable_ruby, :bool, :default => true # true for lower version compatibility
     config_param :auto_typecast, :bool, :default => false # false for lower version compatibility
 
-    BUILTIN_CONFIGURATIONS = %W(type tag output_tag remove_keys renew_record keep_keys enable_ruby renew_time_key auto_typecast)
+    BUILTIN_CONFIGURATIONS = %W(@id @type @label type tag output_tag remove_keys renew_record keep_keys enable_ruby renew_time_key auto_typecast)
 
     # To support log_level option implemented by Fluentd v0.10.43
     unless method_defined?(:log)


### PR DESCRIPTION
I found that this plugin adds system parameters (`@id`, `@type`, `@label`) to a record by mistake.

```
<match test>
  @type         record_reformer
  renew_record  false
  enable_ruby   false
  <record>
    time        ${time}
  </record>
</match>
```

```
2015-12-15 20:29:13 +0900 test: {"data":"foo","@id":"test","@type":"record_reformer","time":"2015-12-15 20:29:13 +0900"}
```

Since record_transformer doesn't have tag-related parameters, I'd like to enable this plugin to cope with a conf file on Fluentd v.0.12.

Regards,