### PR TITLE
Use `@type` instead of type

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Use RubyGems:
 Example:
 
     <match foo.**>
-      type record_reformer
+      @type record_reformer
       remove_keys remove_me
       renew_record false
       enable_ruby false
@@ -56,7 +56,7 @@ reformed.foo {
 Example:
 
     <match foo.**>
-      type record_reformer
+      @type record_reformer
       remove_keys remove_me
       renew_record false
       enable_ruby false


### PR DESCRIPTION
Because fluentd document uses this notation.
We should start to use it.