### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.1.*
   - 2.2.*
   - 2.3.0
+  - 2.4.0
 gemfile:
   - Gemfile
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ rvm:
   - 2.3.0
 gemfile:
   - Gemfile
-  - Gemfile.fluentd.0.12
-  - Gemfile.fluentd.0.10
 matrix:
   exclude:
     - rvm: 2.0.*

--- a/Gemfile.fluentd.0.10
+++ b/Gemfile.fluentd.0.10
@@ -1,4 +1,0 @@
-source "http://rubygems.org"
-
-gem 'fluentd', '~> 0.10.43'
-gemspec

--- a/Gemfile.fluentd.0.12
+++ b/Gemfile.fluentd.0.12
@@ -1,4 +1,0 @@
-source "http://rubygems.org"
-
-gem 'fluentd', '~> 0.12.0'
-gemspec

--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -1,8 +1,11 @@
 require 'ostruct'
+require 'fluent/plugin/output'
 
 module Fluent
-  class RecordReformerOutput < Output
+  class Plugin::RecordReformerOutput < Plugin::Output
     Fluent::Plugin.register_output('record_reformer', self)
+
+    helpers :event_emitter
 
     def initialize
       require 'socket'
@@ -92,7 +95,7 @@ module Fluent
       @hostname = Socket.gethostname
     end
 
-    def emit(tag, es, chain)
+    def process(tag, es)
       tag_parts = tag.split('.')
       tag_prefix = tag_prefix(tag_parts)
       tag_suffix = tag_suffix(tag_parts)
@@ -120,7 +123,6 @@ module Fluent
           router.emit(new_tag, time, new_record)
         end
       }
-      chain.next
     rescue => e
       log.warn "record_reformer: #{e.class} #{e.message} #{e.backtrace.first}"
       log.debug "record_reformer: tag:#{@tag} map:#{@map} record:#{last_record} placeholder_values:#{placeholder_values}"

--- a/lib/fluent/plugin/out_record_reformer.rb
+++ b/lib/fluent/plugin/out_record_reformer.rb
@@ -31,16 +31,6 @@ module Fluent
 
     BUILTIN_CONFIGURATIONS = %W(@id @type @label type tag output_tag remove_keys renew_record keep_keys enable_ruby renew_time_key auto_typecast)
 
-    # To support log_level option implemented by Fluentd v0.10.43
-    unless method_defined?(:log)
-      define_method("log") { $log }
-    end
-
-    # Define `router` method of v0.12 to support v0.10 or earlier
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
-    end
-
     def configure(conf)
       super
 

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -44,7 +44,7 @@ class RecordReformerOutputTest < Test::Unit::TestCase
     hostname ${hostname}
     input_tag ${tag}
     time ${time.to_s}
-    message ${hostname} ${tag_parts.last} ${URI.escape(message)}
+    message ${hostname} ${tag_parts.last} ${URI.encode_www_form_component(message)}
   ]
 
   [:v0, :v1].each do |syntax|

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -173,7 +173,7 @@ EOC
 EOC
         times = [ Time.local(2,2,3,4,5,2010,nil,nil,nil,nil), Time.local(3,2,3,4,5,2010,nil,nil,nil,nil) ]
         msgs = times.map{|t| t.to_s }
-        emits = emit(config, use_v1, msgs)
+        emits = emit(config, syntax, msgs)
         emits.each_with_index do |(tag, time, record), i|
           assert_equal("reformed.#{@tag}", tag)
           assert_equal(times[i].to_i, time)

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -2,15 +2,18 @@ require_relative 'helper'
 require 'time'
 require 'fluent/test/driver/output'
 require 'fluent/plugin/out_record_reformer'
+require 'fluent/test/helpers'
 
 Fluent::Test.setup
 
 class RecordReformerOutputTest < Test::Unit::TestCase
+  include Fluent::Test::Helpers
+
   setup do
     @hostname = Socket.gethostname.chomp
     @tag = 'test.tag'
     @tag_parts = @tag.split('.')
-    @time = Time.local(1,2,3,4,5,2010,nil,nil,nil,nil).to_i
+    @time = event_time("2010-05-04 03:02:01")
     Timecop.freeze(@time)
   end
 
@@ -143,7 +146,7 @@ class RecordReformerOutputTest < Test::Unit::TestCase
       end
 
       test 'renew_time_key' do
-        times = [ Time.local(2,2,3,4,5,2010,nil,nil,nil,nil), Time.local(3,2,3,4,5,2010,nil,nil,nil,nil) ]
+        times = [ Time.at(event_time("2010-05-04 03:02:02")), Time.at(event_time("2010-05-04 03:02:03")) ]
         config = <<EOC
     tag reformed.${tag}
     enable_ruby true
@@ -171,7 +174,7 @@ EOC
       event_time_key ${Time.parse(record["message"]).to_i}
     </record>
 EOC
-        times = [ Time.local(2,2,3,4,5,2010,nil,nil,nil,nil), Time.local(3,2,3,4,5,2010,nil,nil,nil,nil) ]
+        times = [ Time.at(event_time("2010-05-04 03:02:02")), Time.at(event_time("2010-05-04 03:02:03")) ]
         msgs = times.map{|t| t.to_s }
         emits = emit(config, syntax, msgs)
         emits.each_with_index do |(tag, time, record), i|

--- a/test/test_out_record_reformer.rb
+++ b/test/test_out_record_reformer.rb
@@ -50,7 +50,7 @@ class RecordReformerOutputTest < Test::Unit::TestCase
     message ${hostname} ${tag_parts.last} ${URI.encode_www_form_component(message)}
   ]
 
-  [:v0, :v1].each do |syntax|
+  [:v1].each do |syntax|
     sub_test_case 'configure' do
       test 'typical usage' do
         assert_nothing_raised do


### PR DESCRIPTION
I've migrated this plugin to use v0.14 API.
**Notice:** This PR contains BRAKING CHANGES.

Even if this PR is acceptable, please don't merge immediately.

First, we should release dependency Fluentd version locked version to ensure lock dependency for Fluentd v0.12.
And then, please merge this PR.
Finally, we should bump up dependent Fluentd version to 0.14.4 or later, bump up major version, and publish to rubygems.
